### PR TITLE
Misc. cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,56 @@
 # node-cobalt-api
-Node.js Wrapper for the Cobalt API (https://cobalt.qas.im/)
+Node.js wrapper for the Cobalt API (https://cobalt.qas.im/).
 
-#Installation  
-```javascript
-npm install cobalt-node-wrapper
+## Installation
+```shell
+npm install --save cobalt-node-wrapper
 ```
 
-#Usage  
+## Usage
 Acquire an API key from https://cobalt.qas.im/.
+
 ```javascript
-//Require the module
+// Require the module
 var cobaltAPI = require('cobalt-node-wrapper');
-//Create new client
+
+// Create new client
 var cobalt = new cobaltAPI({
   API_KEY: 'YOUR_KEY_HERE'
 });
 
-//Use the API 
+// Use the API
 cobalt.get('/courses', function(err, res) {
-  console.log(res); 
-}); 
+  console.log(res);
+});
 
 cobalt.get('/textbooks', function(err, res) {
-  console.log(res); 
-}); 
+  console.log(res);
+});
 ```
 
-#Using Parameters  
-In order to pass parameters, either put them directly into the URL or pass them as an object  
+## Using Parameters
+In order to pass parameters, either put them directly into the URL or pass them as an object
+
 ```javascript
-cobalt.get('/courses/search',{
-   q:'Computer Science', 
-    limit:5
-  }, function(err, res) {
-    console.log(res);
+cobalt.get('/courses/search', {
+  q: 'Computer Science',
+  limit: 5
+}, function(err, res) {
+  console.log(res);
 });
 
-//Using the ':id' parameter is like using any other parameter.
-cobalt.get('/buildings',{
-   id:'005'
-  }, function(err, res) {
-    console.log(res);
+// Using the ':id' parameter is like using any other parameter.
+cobalt.get('/buildings', {
+  id: '005'
+}, function(err, res) {
+  console.log(res);
 });
 ```
-API key is automatically passed.  
 
-#Contributing
-1. Fork the Repository
+The API key is automatically passed.
+
+## Contributing
+1. Fork the repository
 2. Create a new branch
 3. Make changes and additions as needed
 4. Push changes and make a pull request

--- a/index.js
+++ b/index.js
@@ -20,39 +20,28 @@ CobaltClient.prototype.get = function(path, params, cb) {
 };
 
 CobaltClient.prototype._createEndpoint = function(path, params) {
-    var end_point = BASE_URL + path;
-    var haveParams = Object.keys(params).length !== 0;
-    var parameters = [];
+    var endpoint = BASE_URL + path;
 
-    if (path.indexOf('/search') !== -1 && Object.keys(params).indexOf('q') === -1) {
+    if (path.indexOf('/search') !== -1 && !params.hasOwnProperty('q')) {
         throw new Error('Search query does not have required parameter "q".');
     }
 
     if (params.hasOwnProperty('id')) {
-        end_point += '/' + params['id'];
+        endpoint += '/' + params['id'];
     }
 
-    if (haveParams) {
+    endpoint += '?key=' + this.apiKey;
+
+    if (Object.keys(params).length > 0) {
         for (var key in params) {
             if (params.hasOwnProperty(key)) {
-                parameters.push('&' + key + '=' + params[key]);
+                endpoint += '&' + key + '=' + params[key];
             }
         }
     }
 
-    end_point += '?key=' + this.apiKey;
-
-    if (parameters.length !== 0) {
-        for (var i = 0, len = parameters.length; i < len; i++) {
-            end_point += parameters[i];
-        }
-    }
-
-    return {
-        url: end_point
-    };
+    return endpoint;
 };
-
 
 CobaltClient.prototype._makeRequest = function(method, path, params, cb) {
     if (typeof params === 'function') {
@@ -60,11 +49,11 @@ CobaltClient.prototype._makeRequest = function(method, path, params, cb) {
         params = {};
     }
 
-    var end_point = this._createEndpoint(path, params);
+    var endpoint = this._createEndpoint(path, params);
 
     request({
         method: method,
-        url: end_point.url,
+        url: endpoint,
     }, function(err, response, data) {
         if (err) {
             cb(err, data, response);

--- a/index.js
+++ b/index.js
@@ -1,11 +1,7 @@
 'use strict';
 
-const request = require('request');
-const BASE_URL = 'https://cobalt.qas.im/api/1.0';
-
-function _isValid(key) {
-    return !!key;
-}
+var request = require('request');
+var BASE_URL = 'https://cobalt.qas.im/api/1.0';
 
 function CobaltClient(opts) {
     if (!(this instanceof CobaltClient)) {
@@ -13,7 +9,7 @@ function CobaltClient(opts) {
     }
 
     if (!opts.API_KEY) {
-        throw new Error('Invalid API key provided');
+        throw new Error('An API key must be provided.');
     }
 
     this.apiKey = opts.API_KEY;
@@ -21,53 +17,51 @@ function CobaltClient(opts) {
 
 CobaltClient.prototype.get = function(path, params, cb) {
     this._makeRequest('get', path, params, cb);
-
 };
 
 CobaltClient.prototype._createEndpoint = function(path, params) {
     var end_point = BASE_URL + path;
-    var haveParams = Object.keys(params).length != 0;
+    var haveParams = Object.keys(params).length !== 0;
     var parameters = [];
 
-    if (path.indexOf('/search') != -1 && Object.keys(params).indexOf('q') == -1) {
-        throw new Error('Search query does not have required parameter q.')
+    if (path.indexOf('/search') !== -1 && Object.keys(params).indexOf('q') === -1) {
+        throw new Error('Search query does not have required parameter "q".');
     }
 
-    if ('id' in params) {
-        end_point += `/${params['id']}`;
+    if (params.hasOwnProperty('id')) {
+        end_point += '/' + params['id'];
     }
 
     if (haveParams) {
         for (var key in params) {
-            if (params[key] != undefined) {
-                parameters.push(`&${key}=${params[key]}`);
+            if (params.hasOwnProperty(key)) {
+                parameters.push('&' + key + '=' + params[key]);
             }
         }
     }
 
-    end_point += `?key=${this.apiKey}`
+    end_point += '?key=' + this.apiKey;
 
-
-    if (parameters.length != 0) {
-        for (var i = 0; i < parameters.length; i++) {
+    if (parameters.length !== 0) {
+        for (var i = 0, len = parameters.length; i < len; i++) {
             end_point += parameters[i];
         }
     }
+
     return {
         url: end_point
     };
-
 };
 
 
 CobaltClient.prototype._makeRequest = function(method, path, params, cb) {
-
-    if (typeof(params) === 'function') {
+    if (typeof params === 'function') {
         cb = params;
         params = {};
     }
 
     var end_point = this._createEndpoint(path, params);
+
     request({
         method: method,
         url: end_point.url,
@@ -84,6 +78,7 @@ CobaltClient.prototype._makeRequest = function(method, path, params, cb) {
                     response
                 );
             }
+
             if (typeof data.errors !== 'undefined') {
                 cb(data.errors, data, response);
             } else if (response.statusCode !== 200) {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "cobalt-node-wrapper",
   "version": "1.0.0",
   "description": "Node.js wrapper for the Cobalt API (https://cobalt.qas.im)",
+  "author": "Paul Xu (paulxuca@gmail.com)",
+  "license": "MIT",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/paulxuca/node-cobalt-api"
+  },
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Paul Xu (paulxuca@gmail.com)",
-  "license": "MIT",
   "dependencies": {
     "request": "^2.72.0"
-  },
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/paulxuca/node-cobalt-api"
   }
 }


### PR DESCRIPTION
- README formatting
- Considering the simplicity of the package, I opted to remove usages of `const` and template strings so that it'd work in older versions of Node too
- Cleaned up the `_createEndpoint` function
